### PR TITLE
support multiple path configs per template

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -25,10 +25,14 @@ module.exports = (grunt) ->
 
     pathfinder:
       requirejs:
-        files: 'tmp/requirejs_output.js': ['test/dir/**/*.js']
+        files:
+          js: ['test/dir/**/*.js']
+        output: 'tmp/requirejs_output.js'
         template: 'test/requirejs_template.js'
       importless:
-        files: 'tmp/importless_output.less': ['test/dir/**/*.{css,less}']
+        files:
+          styles: ['test/dir/**/*.{css,less}']
+        output: 'tmp/importless_output.less'
         template: 'test/importless_template.less'
 
     clean: ['tmp/']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -25,12 +25,12 @@ module.exports = (grunt) ->
 
     pathfinder:
       requirejs:
-        files:
+        paths:
           js: ['test/dir/**/*.js']
         output: 'tmp/requirejs_output.js'
         template: 'test/requirejs_template.js'
       importless:
-        files:
+        paths:
           styles: ['test/dir/**/*.{css,less}']
         output: 'tmp/importless_output.less'
         template: 'test/importless_template.less'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -34,6 +34,12 @@ module.exports = (grunt) ->
           styles: ['test/dir/**/*.{css,less}']
         output: 'tmp/importless_output.less'
         template: 'test/importless_template.less'
+      index:
+        paths:
+          js: ['tmp/*.js']
+          less: ['tmp/*.less']
+        output: 'tmp/index_output.html'
+        template: 'test/index_template.html'
 
     clean: ['tmp/']
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,18 @@ If the plugin has been installed correctly, running `grunt --help` at the comman
 [package.json]: https://npmjs.org/doc/json.html
 
 ### Overview
-Inside your Gruntfile, add a section named `pathfinder`. This section specifies the possible locations of files, the template which the found filepaths are passed to and the output file (compiled template).
+Inside your Gruntfile, add a section named `pathfinder`. This section specifies the groups of file (`paths`), the `template` to which the found filepaths are passed to and the `output` file (compiled template).
 
 ```js
 grunt.initConfig({
   pathfinder: {
-    main: {
-      files:
-        'path/to/output.js': ['some/**/*.js', 'other/whatever.js'],
-      template: 'path/to/template.js'
+    indexhtml: {
+      paths: {
+        css: ['dir/**/*.css', 'also/this/other.css'],
+        js: ['scripts/**/*.js']
+      },
+      template: 'template/index.html',
+      output: 'dist/index.html'
     }
   }
 });
@@ -42,16 +45,21 @@ grunt.initConfig({
 
 There are a number of options available. Please review the [minimatch options here](https://github.com/isaacs/minimatch#options). As well as some additional options as follows:
 
-#### files
+#### paths
 Type: `object`
 
-`key:value` pair that describes `outputFile:filesToImport`.
-This defines where the compiled template output will be saved to (key) where files are being looked for (value). Value can be a string or an array of files and/or minimatch patterns.
+`key:value` pairs that describes `group:pattern`.
+The name of the group is also the variable name that is available in the template. Hence, you can have multiple groups and multiple variables available in your template. The pattern is a minimatch pattern. The found files are stores as filepaths in the array variable (group).
 
 #### template
 Type: `String`
 
 The template file will be parsed using `grunt.template` and the found file paths will be passed as data. The `paths` array is available in your template file.
+
+#### output
+Type: `String`
+
+To which file the compiled template will be saved to.
 
 ### Events
 `grunt-pathfinder` emits and events using `grunt.event.emit` called `pathfinder-paths`. If you listen on this event, you can manipulate the paths array (e.g. filter it) and save it before it gets passed to the template. A use case of this is the [importless][] example config in the [Gruntfile](https://github.com/excellenteasy/grunt-pathfinder/blob/master/Gruntfile.coffee#L16-22).

--- a/js
+++ b/js
@@ -1,0 +1,1 @@
+requirejs(["core/core"].concat(["test/dir/module2", "test/dir/subfolder/module1", ]), function() {})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-pathfinder",
   "description": "Find files and process their paths in a template.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/excellenteasy/grunt-pathfinder.git",
   "author": {
     "name": "David Pfahler",

--- a/styles
+++ b/styles
@@ -1,0 +1,5 @@
+// importless example template for grunt-pathfinder
+
+@import "test/dir/test.less";
+
+@import "test/dir/test2.less";

--- a/test/importless_template.less
+++ b/test/importless_template.less
@@ -1,5 +1,4 @@
 // importless example template for grunt-pathfinder
-<%
-_.each(styles, function(path) { %>
+<%_.each(styles, function(path) { %>
 @import "<%= path %>";
 <% }); %>

--- a/test/importless_template.less
+++ b/test/importless_template.less
@@ -1,5 +1,5 @@
 // importless example template for grunt-pathfinder
 <%
-_.each(paths, function(path) { %>
+_.each(styles, function(path) { %>
 @import "<%= path %>";
 <% }); %>

--- a/test/index_template.html
+++ b/test/index_template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <% _.each(less, function(lessFile) { %><link href="<%= lessFile %>" rel="stylesheet" type="text/less" /><% }); %>
+</head>
+<body>
+  <% _.each(js, function(jsFile) { %><script src="<%= jsFile %>"></script><% }); %>
+</body>
+</html>

--- a/test/pathfinder_test.coffee
+++ b/test/pathfinder_test.coffee
@@ -3,15 +3,24 @@
 grunt = require('grunt')
 
 exports.pathfinder =
+
   requirejs: (test) ->
     test.expect 1
     actual = grunt.file.read 'tmp/requirejs_output.js'
     expected = 'requirejs(["core/core"].concat(["test/dir/module2", "test/dir/subfolder/module1", ]), function() {})\n'
     test.equal actual, expected, 'generated requirejs config file correctly'
     test.done()
+
   importless: (test) ->
     test.expect 1
     actual = grunt.file.read 'tmp/importless_output.less'
     expected = '// importless example template for grunt-pathfinder\n\n@import "test/dir/test.less";\n\n@import "test/dir/test2.less";\n\n'
     test.equal actual, expected, 'generated main less file correctly'
+    test.done()
+
+  index: (test) ->
+    test.expect 1
+    actual = grunt.file.read 'tmp/index_output.html'
+    expected = '<!DOCTYPE HTML>\n<html lang="en-US">\n<head>\n  <link href="tmp/importless_output.less" rel="stylesheet" type="text/less" />\n</head>\n<body>\n  <script src="tmp/requirejs_output.js"></script>\n</body>\n</html>\n'
+    test.equal actual, expected, 'generate html correctly'
     test.done()

--- a/test/pathfinder_test.coffee
+++ b/test/pathfinder_test.coffee
@@ -12,6 +12,6 @@ exports.pathfinder =
   importless: (test) ->
     test.expect 1
     actual = grunt.file.read 'tmp/importless_output.less'
-    expected = '// importless example template for grunt-pathfinder\n\n@import "test/dir/test.less";\n\n@import "test/dir/test2.less";\n'
+    expected = '// importless example template for grunt-pathfinder\n\n@import "test/dir/test.less";\n\n@import "test/dir/test2.less";\n\n'
     test.equal actual, expected, 'generated main less file correctly'
     test.done()

--- a/test/requirejs_template.js
+++ b/test/requirejs_template.js
@@ -1,1 +1,1 @@
-requirejs(["core/core"].concat([<% _.each(paths, function(js) { print('"'+js.replace('.js', '')+'", ') }); %>]), function() {})
+requirejs(["core/core"].concat([<% _.each(js, function(jsFile) { print('"'+jsFile.replace('.js', '')+'", ') }); %>]), function() {})


### PR DESCRIPTION
Note: **This will beak API if implemented**
# Example Gruntfile config

``` coffeescript
pathfinder:
  indexhtml:
    paths:
      css: ['dir/**/*.css', 'also/this/other.css']
      js: ['scripts/**/*.js']
    template: 'template/index.html'
    output: 'dist/index.html'
```

Every "destination" in files (i.e. the object's key) should be available as a variable in the specified `template`. So, multiple sets of paths that are different in their nature can be passed to a single template that can distinguish between them. 
# Example `template/index.html` template

``` html
<!DOCTYPE HTML>
<html lang="en-US">
<head>
  <% _.each(css, function(cssFile) { %>
  <link href="<%= cssFile %>" rel="stylesheet" type="text/css" />
  <% }); %>
</head>
<body>
  <% _.each(js, function(jsFile) { %>
  <script src="<%= jsFile %>"></script>
  <% }); %>
</body>
</html>
```
